### PR TITLE
Add licence to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Typing :: Typed"
 ]
+license = {file = "LICENSE"}
 dynamic = ["version"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
     "Typing :: Typed"
 ]
 license = {file = "LICENSE"}


### PR DESCRIPTION
Some detection tools does not detect the licence type because not defined in pyproject.toml (liccheck)